### PR TITLE
Add tests for log rate limiting

### DIFF
--- a/apps/log_rate_limit.go
+++ b/apps/log_rate_limit.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-test-helpers/cf"
+	"github.com/cloudfoundry/cf-test-helpers/helpers"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
@@ -16,8 +18,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
-	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
 )
 
 var _ = AppsDescribe("log rate limit", func() {

--- a/apps/log_rate_limit.go
+++ b/apps/log_rate_limit.go
@@ -1,4 +1,4 @@
-package windows
+package apps
 
 import (
 	"regexp"
@@ -6,19 +6,21 @@ import (
 	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-test-helpers/cf"
-	"github.com/cloudfoundry/cf-test-helpers/helpers"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gbytes"
-	. "github.com/onsi/gomega/gexec"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
 )
 
-var _ = WindowsDescribe("App Limits", func() {
+var _ = AppsDescribe("log rate limit", func() {
 	var appName string
 
 	BeforeEach(func() {
@@ -26,24 +28,17 @@ var _ = WindowsDescribe("App Limits", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"-s", Config.GetWindowsStack(),
-			"-b", Config.GetHwcBuildpackName(),
-			"-m", "256m",
-			"-p", assets.NewAssets().Nora,
+			"-b", Config.GetRubyBuildpackName(),
+			"-m", DEFAULT_MEMORY_LIMIT,
+			"-p", assets.NewAssets().Dora,
 			"-l", "1K",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 
 	AfterEach(func() {
 		app_helpers.AppReport(appName)
 
-		Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).Should(Exit(0))
-	})
-
-	It("does not allow the app to use more memory than allowed", func() {
-		response := helpers.CurlApp(Config, appName, "/leakmemory/300")
-		Expect(response).To(ContainSubstring("Insufficient memory"))
+		Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
 	})
 
 	Context("when a log rate limit is defined", func() {
@@ -75,4 +70,5 @@ var _ = WindowsDescribe("App Limits", func() {
 			Consistently(logs).ShouldNot(Say("11111"), "logs above the limit were not dropped")
 		})
 	})
+
 })

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -47,7 +47,7 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-const minCliVersion = "6.33.1"
+const minCliVersion = "8.5.0"
 
 func TestCATS(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
### What is this change about?

The cf CLI, Cloud Controller API and Diego are being extended with support for defining log rate limit quotas. This PR is an alternative version of https://github.com/cloudfoundry/cf-acceptance-tests/pull/582.

For these tests to run the minCliVersion was updated to a version of the cf CLI that supports specifying a log rate limit when pushing an application.

I've made this PR against the somewhat out of date `fix/increase-grpc-context-timeout` branch, which means that the imports needed to be updated to refer to older versions of cf-test-helpers and ginkgo.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/pull/582

### Please check all that apply for this PR:

- [X] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config